### PR TITLE
Add ore vein generation

### DIFF
--- a/finders.c
+++ b/finders.c
@@ -2188,7 +2188,7 @@ int32_t getOreVeinBlockAt(int x, int y, int z, OreVeinParameters* params)
     ov_copper = {COPPER_ORE, RAW_COPPER_BLOCK, GRANITE, 0, 50},
     ov_iron = {IRON_ORE, RAW_IRON_BLOCK, TUFF, -60, -8};
     static const int min_y = MIN(ov_copper.minY, ov_iron.minY);
-    static const int max_y = MIN(ov_copper.maxY, ov_iron.maxY);
+    static const int max_y = MAX(ov_copper.maxY, ov_iron.maxY);
 
     if (y < min_y || y > max_y) {
         return -1;

--- a/finders.c
+++ b/finders.c
@@ -2187,8 +2187,8 @@ int32_t getOreVeinBlockAt(int x, int y, int z, OreVeinParameters* params)
     static const OreVeinConfig
     ov_copper = {COPPER_ORE, RAW_COPPER_BLOCK, GRANITE, 0, 50},
     ov_iron = {IRON_ORE, RAW_IRON_BLOCK, TUFF, -60, -8};
-    static const int min_y = MIN(ov_copper.minY, ov_iron.minY);
-    static const int max_y = MAX(ov_copper.maxY, ov_iron.maxY);
+    static const int min_y = MIN(0 /*ov_copper.minY*/, -60 /*ov_iron.minY*/);
+    static const int max_y = MAX(50 /*ov_copper.maxY*/, -8 /*ov_iron.maxY*/);
 
     if (y < min_y || y > max_y) {
         return -1;

--- a/finders.h
+++ b/finders.h
@@ -348,6 +348,8 @@ enum Blocks {
     NETHERRACK,
     NETHER_GOLD_ORE,
     NETHER_QUARTZ_ORE,
+    RAW_COPPER_BLOCK,
+    RAW_IRON_BLOCK,
     REDSTONE_ORE,
     SOUL_SAND,
     STONE,
@@ -507,6 +509,33 @@ int getOreYPos(int mc, int oreType, RandomSource rnd);
 Pos3List generateOrePositions(const Generator *g, const SurfaceNoise *sn, OreConfig config, Pos3 bPos, RandomSource rnd);
 
 Pos3List generateVeinPart(int mc, OreConfig config, RandomSource rnd, double offsetXPos, double offsetXNeg, double offsetZPos, double offsetZNeg, double offsetYPos, double offsetYNeg, int startX, int startY, int startZ, int oreSize, int radius);
+
+enum OreVeins {
+    CopperVein,
+    IronVein,
+};
+
+STRUCT(OreVeinConfig)
+{
+    uint32_t oreBlock;
+    uint32_t rawOreBlock;
+    uint32_t fillerBlock;
+    int32_t  minY;
+    int32_t  maxY;
+};
+
+STRUCT(OreVeinParameters)
+{
+    DoublePerlinNoise oreVeininess;
+    DoublePerlinNoise oreVeinA;
+    DoublePerlinNoise oreVeinB;
+    DoublePerlinNoise oreGap;
+    Xoroshiro         posRandom;
+};
+
+int initOreVeinNoise(OreVeinParameters *params, uint64_t ws, int mc);
+
+int32_t getOreVeinBlockAt(int x, int y, int z, OreVeinParameters* params);
 
 /* Finds a suitable pseudo-random location in the specified area.
  * This function is used to determine the positions of spawn and strongholds.

--- a/rng.h
+++ b/rng.h
@@ -284,11 +284,11 @@ static inline int xNextIntJBetween(Xoroshiro *xr, const int min, const int max)
 
 static inline Xoroshiro xAtPos(Xoroshiro *xr, int x, int y, int z)
 {
-    uint64_t l = x * 3129871 ^ z * 116129781L ^ y;
+    int64_t l = (int64_t)(x * 3129871) ^ (int64_t)z * 116129781L ^ (int64_t)y;
     l = l * l * 42317861L + l * 11L;
     l >>= 16;
 
-    return (Xoroshiro) {l ^ xr->lo, xr->hi};
+    return (Xoroshiro) {(uint64_t)l ^ xr->lo, xr->hi};
 }
 
 // expand as necessary

--- a/rng.h
+++ b/rng.h
@@ -282,6 +282,15 @@ static inline int xNextIntJBetween(Xoroshiro *xr, const int min, const int max)
     return xNextIntJ(xr, max - min + 1) + min;
 }
 
+static inline Xoroshiro xAtPos(Xoroshiro *xr, int x, int y, int z)
+{
+    uint64_t l = x * 3129871 ^ z * 116129781L ^ y;
+    l = l * l * 42317861L + l * 11L;
+    l >>= 16;
+
+    return (Xoroshiro) {l ^ xr->lo, xr->hi};
+}
+
 // expand as necessary
 STRUCT(RandomSource)
 {
@@ -421,6 +430,10 @@ static inline double clampedLerp(double part, double from, double to)
     if (part <= 0) return from;
     if (part >= 1) return to;
     return lerp(part, from, to);
+}
+
+static inline double clampedMap(double input, double inputMin, double inputMax, double ouputMin, double outputMax) {
+    return clampedLerp((input - inputMin) / (inputMax - inputMin), ouputMin, outputMax);
 }
 
 /* Find the modular inverse: (1/x) | mod m.


### PR DESCRIPTION
Thanks to @picawawa4000. This is mostly ported from his [mcmapper](https://github.com/picawawa4000/mcmapper). Currently interpolation is ignored, which causes some incorrections.

Example usage:

```c
int main() {
    int version = MC_NEWEST;
    uint64_t seed = 0;
    OreVeinParameters params;
    if (!initOreVeinNoise(&params, seed, version)) {
        return 1;
    }

    for (int x = -32; x < 32; x++) {
        for (int z = -32; z < 32; z++) {
            for (int y = -60; y <= 50; y++) {
                int block = getOreVeinBlockAt(x, y, z, &params);
                if (block == -1 || block == GRANITE || block == TUFF) {
                    continue;
                }
                printf("Ore vein block %d at %d %d %d\n", block, x, y, z);
            }
        }
    }

    return 0;
}
```