### PR TITLE
fix getStrongholdPieces going out of bounds

### DIFF
--- a/features/stronghold.c
+++ b/features/stronghold.c
@@ -191,7 +191,10 @@ L_box_end:
         q = q->next; //queue++;
     }
     q->next = p;
-
+    
+    if (*env->n >= env->nmax){
+        env->generationStopped = 1;
+    }
     return 1;
 }
 

--- a/features/stronghold.c
+++ b/features/stronghold.c
@@ -191,7 +191,7 @@ L_box_end:
         q = q->next; //queue++;
     }
     q->next = p;
-    
+
     if (*env->n >= env->nmax){
         env->generationStopped = 1;
     }


### PR DESCRIPTION
I found that `getStrongholdPieces` can return more pieces than the buffer size `n`, causing memory issues

`env.nmax` is set but never used.
this pr adds a check for `*env->n >= env->nmax` at the end of `addStrongholdPiece`.

Here is example code to recreate this:
It prints: 
"remaining sh: 128
Generated 109 Pieces. max pieces = 100"
then crashes  as memory for Generator g is corrupted.

```C
#include "./cubiomes/features/stronghold.h"
#include "./cubiomes/finders.h"
#include "./cubiomes/biomes.h"
#include "./cubiomes/generator.h"

#include <stdint.h>
#include <stdio.h>

int main() {

  int nmax = 100;
  int mc = MC_NEWEST;
  Generator g;
  setupGenerator(&g, mc, 0);
  StructureSaltConfig ssc;
  StrongholdIter sh;
  uint64_t seed = 8833883388338848ull;
  Pos pos = initFirstStronghold(&sh, mc, seed);

  applySeed(&g, DIM_OVERWORLD, seed);
  int sh_remain = 128;
  while (sh_remain) {
    sh_remain = nextStronghold(&sh, &g);
    printf("remaining sh: %d\n",sh_remain);
    Piece list[nmax];
    int chunkX = sh.pos.x >> 4;
    int chunkZ = sh.pos.z >> 4;
    int biomeId = getBiomeAt(&g, 1, sh.pos.x, 256, sh.pos.z);
    int err_ssc = getStructureSaltConfig(Stronghold, mc, biomeId, &ssc);
    int num_pieces =
        getStrongholdLoot(list, nmax, ssc, mc, seed, chunkX, chunkZ);
    printf("Generated %d Pieces. max pieces = %d\n", num_pieces, nmax);
  }
  return 0;
}
```