### PR TITLE
Fix C++ incompatibility + numerous other changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,24 +8,12 @@ docs/LayerSummary.synctex.gz
 docs/LayerSummary.toc
 *.o
 *.a
-a.out
+*.out
+
+*.so
+*.dylib
+*.dll
 
 build
 
 .idea
-
-*.dll
-
-# From toptal.com/developers/gitignore
-CMakeLists.txt.user
-CMakeCache.txt
-CMakeFiles
-CMakeScripts
-Testing
-Makefile
-cmake_install.cmake
-install_manifest.txt
-compile_commands.json
-CTestTestfile.cmake
-_deps
-CMakeUserPresets.json

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,19 @@ a.out
 build
 
 .idea
+
+*.dll
+
+# From toptal.com/developers/gitignore
+CMakeLists.txt.user
+CMakeCache.txt
+CMakeFiles
+CMakeScripts
+Testing
+Makefile
+cmake_install.cmake
+install_manifest.txt
+compile_commands.json
+CTestTestfile.cmake
+_deps
+CMakeUserPresets.json

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ if (WIN32)
 	set(CMAKE_C_FLAGS "-D_WIN32")
 endif()
 
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -pedantic")
 set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -O3 -DNDEBUG")
 set(CMAKE_C_FLAGS_DEBUG "-O0 -g3 -DDEBUG")
 
@@ -206,9 +206,13 @@ set_property(TARGET objects PROPERTY POSITION_INDEPENDENT_CODE 1)
 add_library(cubiomes SHARED $<TARGET_OBJECTS:objects>)
 add_library(cubiomes_static STATIC $<TARGET_OBJECTS:objects>)
 
-if (WIN32)
-	set_target_properties(cubiomes PROPERTIES PREFIX "")
-endif()
+set_target_properties(cubiomes PROPERTIES
+	LIBRARY_OUTPUT_DIRECTORY ".."
+	RUNTIME_OUTPUT_DIRECTORY ".."
+)
+set_target_properties(cubiomes_static PROPERTIES
+    ARCHIVE_OUTPUT_DIRECTORY ".."
+)
 
 install(TARGETS cubiomes cubiomes_static DESTINATION lib)
 install(FILES ${HEADERS} DESTINATION include)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -210,14 +210,6 @@ if (WIN32)
 	set_target_properties(cubiomes PROPERTIES PREFIX "")
 endif()
 
-set_target_properties(cubiomes PROPERTIES
-	LIBRARY_OUTPUT_DIRECTORY ".."
-	RUNTIME_OUTPUT_DIRECTORY ".."
-)
-set_target_properties(cubiomes_static PROPERTIES
-    ARCHIVE_OUTPUT_DIRECTORY ".."
-)
-
 install(TARGETS cubiomes cubiomes_static DESTINATION lib)
 install(FILES ${HEADERS} DESTINATION include)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -210,6 +210,14 @@ if (WIN32)
 	set_target_properties(cubiomes PROPERTIES PREFIX "")
 endif()
 
+set_target_properties(cubiomes PROPERTIES
+	LIBRARY_OUTPUT_DIRECTORY ".."
+	RUNTIME_OUTPUT_DIRECTORY ".."
+)
+set_target_properties(cubiomes_static PROPERTIES
+    ARCHIVE_OUTPUT_DIRECTORY ".."
+)
+
 install(TARGETS cubiomes cubiomes_static DESTINATION lib)
 install(FILES ${HEADERS} DESTINATION include)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ if (WIN32)
 	set(CMAKE_C_FLAGS "-D_WIN32")
 endif()
 
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -pedantic")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra")
 set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -O3 -DNDEBUG")
 set(CMAKE_C_FLAGS_DEBUG "-O0 -g3 -DDEBUG")
 
@@ -206,13 +206,9 @@ set_property(TARGET objects PROPERTY POSITION_INDEPENDENT_CODE 1)
 add_library(cubiomes SHARED $<TARGET_OBJECTS:objects>)
 add_library(cubiomes_static STATIC $<TARGET_OBJECTS:objects>)
 
-set_target_properties(cubiomes PROPERTIES
-	LIBRARY_OUTPUT_DIRECTORY ".."
-	RUNTIME_OUTPUT_DIRECTORY ".."
-)
-set_target_properties(cubiomes_static PROPERTIES
-    ARCHIVE_OUTPUT_DIRECTORY ".."
-)
+if (WIN32)
+	set_target_properties(cubiomes PROPERTIES PREFIX "")
+endif()
 
 install(TARGETS cubiomes cubiomes_static DESTINATION lib)
 install(FILES ${HEADERS} DESTINATION include)

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ Below is a list of all the major additions:
 - Terrain generation (1.18+).
 - Various bug fixes.
 
+This fork does **not** support the Microsoft Visual C++ (MSVC) compiler.
+
 ## Java bindings
 I have set up the automatic creation of Java bindings based on commits to the master branch. See the [java-bindings](https://github.com/xpple/cubiomes/tree/java-bindings) branch for more information.
 
@@ -35,6 +37,7 @@ You should be familiar with the C programming language. A basic understanding of
 
 This section is meant to give you a quick starting point with small example programs if you want to use this library to find your own biome-dependent features.
 
+All terminal commands seen below are for Unix/Linux systems; Windows is similar, barring some minor adjustments.
 
 ### Biome Generator
 
@@ -79,7 +82,7 @@ You can compile this code by creating a shared library (`libcubiomes.so`, `libcu
 ```shell
 $ cd cubiomes
 $ cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
-$ cmake --build build && cp build/libcubiomes.so .
+$ cmake --build build
 ```
 Then you can compile your program, while linking the archive or shared library, using either of the following commands.
 ```shell

--- a/README.md
+++ b/README.md
@@ -75,14 +75,14 @@ int main()
 }
 ```
 
-You can compile this code by creating a shared library (libcubiomes.[so/dylib/dll]) or an archive (libcubiomes_static.a) using the CMake build script:
-```bash
+You can compile this code by creating a shared library (`libcubiomes.so`, `libcubiomes.dylib` or `cubiomes.dll` depending on your OS) or an archive (`libcubiomes_static.a`) using the CMake build script:
+```shell
 $ cd cubiomes
 $ cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
-$ cmake --build build
+$ cmake --build build && cp build/libcubiomes.so .
 ```
 Then you can compile your program, while linking the archive or shared library, using either of the following commands.
-```bash
+```shell
 $ gcc find_biome_at.c -L. -lcubiomes -O3 -Wall -Wextra -fwrapv -lm # dynamic
 $ gcc find_biome_at.c libcubiomes_static.a -O3 -Wall -Wextra -fwrapv -lm # static
 ```
@@ -93,7 +93,7 @@ The option `-fwrapv` enforces two's complement for signed integer overflow, whic
 If the archive fails to generate, or the compilation claims the library's functions are undefined or missing, run `cmake --build build --target clean` to delete the failed archive, then retry the process.
 
 Running the program should output:
-```bash
+```shell
 $ ./a.out
 Seed 262 has a Mushroom Fields biome at block position (0, 0).
 ```

--- a/README.md
+++ b/README.md
@@ -75,15 +75,16 @@ int main()
 }
 ```
 
-You can compile this code by creating a shared library (libcubiomes.[so/dylib/dll]) using the CMake build script:
-```
+You can compile this code by creating a shared library (libcubiomes.[so/dylib/dll]) or an archive (libcubiomes_static.a) using the CMake build script:
+```bash
 $ cd cubiomes
 $ cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
-$ cmake --build build && cp build/libcubiomes.so .
+$ cmake --build build
 ```
-Then you can compile your program, while linking the archive, using either of the following commands.
-```
-$ gcc find_biome_at.c -L. -lcubiomes -O3 -Wall -Wextra -fwrapv -lm
+Then you can compile your program, while linking the archive or shared library, using either of the following commands.
+```bash
+$ gcc find_biome_at.c -L. -lcubiomes -O3 -Wall -Wextra -fwrapv -lm # dynamic
+$ gcc find_biome_at.c libcubiomes_static.a -O3 -Wall -Wextra -fwrapv -lm # static
 ```
 Both commands assume that your source code is saved as `find_biome_at.c` in the Cubiomes working directory. If your makefile is configured to use pthreads, you may also need to add the `-lpthread` option for the compiler.
 
@@ -92,7 +93,7 @@ The option `-fwrapv` enforces two's complement for signed integer overflow, whic
 If the archive fails to generate, or the compilation claims the library's functions are undefined or missing, run `cmake --build build --target clean` to delete the failed archive, then retry the process.
 
 Running the program should output:
-```
+```bash
 $ ./a.out
 Seed 262 has a Mushroom Fields biome at block position (0, 0).
 ```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # cubiomes
 
-Cubiomes is a standalone library, written in C, that mimics the biome and feature generation of Minecraft Java Edition.
+Cubiomes is a standalone library, written in C, that mimics the biome and feature generation of *Minecraft: Java Edition*.
 It is intended as a powerful tool to devise very fast, custom seed-finding applications and large-scale map viewers with minimal memory usage.
 
 ## Relationship to upstream
@@ -23,7 +23,7 @@ I have set up the automatic creation of Java bindings based on commits to the ma
 
 #### Cubiomes-Viewer
 
-If you want to get started without coding, there is now also a [graphical application](https://github.com/Cubitect/cubiomes-viewer) based on this library.
+If you want to get started without coding, there is a [graphical application](https://github.com/Cubitect/cubiomes-viewer) based on the pre-forked version of this library.
 
 
 #### Audience
@@ -75,21 +75,23 @@ int main()
 }
 ```
 
-You can compile this code either by directly adding a target to the makefile via
+You can compile this code by creating an archive of the library (libcubiomes.a) using the provided makefile:
 ```
 $ cd cubiomes
-$ make
+$ make        # on Linux, or e.g. mingw32-make.exe if using MSYS2 on Windows
 ```
-...or you can compile and link to a cubiomes archive using either of the following commands.
+Then you can compile your program, while linking the archive, using either of the following commands.
 ```
-$ gcc find_biome_at.c libcubiomes.a -fwrapv -lm   # static
-$ gcc find_biome_at.c -L. -lcubiomes -fwrapv -lm  # dynamic
+$ gcc find_biome_at.c libcubiomes.a -fwrapv -lm   # static; or gcc.exe [...] on Windows
+$ gcc find_biome_at.c -L. -lcubiomes -fwrapv -lm  # dynamic; or gcc.exe [...] on Windows
 ```
-Both commands assume that your source code is saved as `find_biome_at.c` in the cubiomes working directory. If your makefile is configured to use pthreads, you may also need to add the `-lpthread` option for the compiler.
+Both commands assume that your source code is saved as `find_biome_at.c` in the Cubiomes working directory. If your makefile is configured to use pthreads, you may also need to add the `-lpthread` option for the compiler.
 The option `-fwrapv` enforces two's complement for signed integer overflow, which is otherwise undefined behavior. It is not really necessary for this example, but it is a common pitfall when dealing with code that emulates the behavior of Java.
+If the archive fails to generate, or the compilation claims the library's functions are undefined or missing, run `make clean`/`mingw32-make.exe clean` to delete the failed archive, then retry the process.
+
 Running the program should output:
 ```
-$ ./a.out
+$ ./a.out     # or ./a.exe on Windows
 Seed 262 has a Mushroom Fields biome at block position (0, 0).
 ```
 
@@ -281,7 +283,7 @@ int main()
 
 #### Strongholds and Spawn
 
-Strongholds, as well as the world spawn point, actually search until they find a suitable location, rather than checking a single spot like most other structures. This causes them to be particularly performance expensive to find. Furthermore, the positions of strongholds have to be generated in a certain order, which can be done in iteratively with `initFirstStronghold()` and `nextStronghold()`. For the world spawn, the generation starts with a search for a suitable biome near the origin and will continue until a grass or podzol block is found. There is no reliable way to check actual blocks, so the search relies on a statistic, matching grass presence to biomes. Alternatively, we can simply use `estimateSpawn()` and terminate the search after the first biome check under the assumption that grass is nearby.
+Strongholds, as well as worlds' spawnpoints, actually search until they find a suitable location, rather than checking a single spot like most other structures. This causes them to be particularly slow to find. Furthermore, the positions of strongholds have to be generated in a certain order, which can be done in iteratively with `initFirstStronghold()` and `nextStronghold()`. For the world spawn, the exact coordinate is found after a search for a grass or podzol block prior to 1.18, or for any topsolid nonwaterlogged block in 1.18+; this library cannot model individual blocks, so the search relies on heuristics such as biomes and climate-dependent world heights. Alternatively, we can simply use `estimateSpawn()` and terminate the search after the first biome/climate check under the assumption that grass/a topsolid nonwaterlogged block is nearby.
 
 
 ```C

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Below is a list of all the major additions:
 - Terrain generation (1.18+).
 - Various bug fixes.
 
-This fork does **not** support the Microsoft Visual C++ (MSVC) compiler.
+MSVC is **not** supported for this fork. Please use MinGW, UCRT64, Clang, or GCC.
 
 ## Java bindings
 I have set up the automatic creation of Java bindings based on commits to the master branch. See the [java-bindings](https://github.com/xpple/cubiomes/tree/java-bindings) branch for more information.
@@ -86,8 +86,8 @@ $ cmake --build build
 ```
 Then you can compile your program, while linking the archive or shared library, using either of the following commands.
 ```shell
-$ gcc find_biome_at.c -L. -lcubiomes -O3 -Wall -Wextra -fwrapv -lm # dynamic
-$ gcc find_biome_at.c libcubiomes_static.a -O3 -Wall -Wextra -fwrapv -lm # static
+$ gcc find_biome_at.c -Lbuild -Wl,-rpath,build -lcubiomes -O3 -Wall -Wextra -fwrapv -lm # dynamic
+$ gcc find_biome_at.c -Lbuild -lcubiomes_static -O3 -Wall -Wextra -fwrapv -lm # static
 ```
 Both commands assume that your source code is saved as `find_biome_at.c` in the Cubiomes working directory. If your makefile is configured to use pthreads, you may also need to add the `-lpthread` option for the compiler.
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ I have set up the automatic creation of Java bindings based on commits to the ma
 
 #### Cubiomes-Viewer
 
-If you want to get started without coding, there is a [graphical application](https://github.com/Cubitect/cubiomes-viewer) based on the pre-forked version of this library.
+If you want to get started without coding, there is a [graphical application](https://github.com/Cubitect/cubiomes-viewer) based on the upstream version of this library.
 
 
 #### Audience
@@ -75,23 +75,25 @@ int main()
 }
 ```
 
-You can compile this code by creating an archive of the library (libcubiomes.a) using the provided makefile:
+You can compile this code by creating a shared library (libcubiomes.[so/dylib/dll]) using the CMake build script:
 ```
 $ cd cubiomes
-$ make        # on Linux, or e.g. mingw32-make.exe if using MSYS2 on Windows
+$ cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
+$ cmake --build build && cp build/libcubiomes.so .
 ```
 Then you can compile your program, while linking the archive, using either of the following commands.
 ```
-$ gcc find_biome_at.c libcubiomes.a -fwrapv -lm   # static; or gcc.exe [...] on Windows
-$ gcc find_biome_at.c -L. -lcubiomes -fwrapv -lm  # dynamic; or gcc.exe [...] on Windows
+$ gcc find_biome_at.c -L. -lcubiomes -O3 -Wall -Wextra -fwrapv -lm
 ```
 Both commands assume that your source code is saved as `find_biome_at.c` in the Cubiomes working directory. If your makefile is configured to use pthreads, you may also need to add the `-lpthread` option for the compiler.
+
 The option `-fwrapv` enforces two's complement for signed integer overflow, which is otherwise undefined behavior. It is not really necessary for this example, but it is a common pitfall when dealing with code that emulates the behavior of Java.
-If the archive fails to generate, or the compilation claims the library's functions are undefined or missing, run `make clean`/`mingw32-make.exe clean` to delete the failed archive, then retry the process.
+
+If the archive fails to generate, or the compilation claims the library's functions are undefined or missing, run `cmake --build build --target clean` to delete the failed archive, then retry the process.
 
 Running the program should output:
 ```
-$ ./a.out     # or ./a.exe on Windows
+$ ./a.out
 Seed 262 has a Mushroom Fields biome at block position (0, 0).
 ```
 
@@ -283,7 +285,7 @@ int main()
 
 #### Strongholds and Spawn
 
-Strongholds, as well as worlds' spawnpoints, actually search until they find a suitable location, rather than checking a single spot like most other structures. This causes them to be particularly slow to find. Furthermore, the positions of strongholds have to be generated in a certain order, which can be done in iteratively with `initFirstStronghold()` and `nextStronghold()`. For the world spawn, the exact coordinate is found after a search for a grass or podzol block prior to 1.18, or for any topsolid nonwaterlogged block in 1.18+; this library cannot model individual blocks, so the search relies on heuristics such as biomes and climate-dependent world heights. Alternatively, we can simply use `estimateSpawn()` and terminate the search after the first biome/climate check under the assumption that grass/a topsolid nonwaterlogged block is nearby.
+Strongholds, as well as the world spawn point, actually search until they find a suitable location, rather than checking a single spot like most other structures. This causes them to be particularly slow to find. Furthermore, the positions of strongholds have to be generated in a certain order, which can be done in iteratively with `initFirstStronghold()` and `nextStronghold()`. For the world spawn, the exact coordinate is found after a search for a grass or podzol block prior to 1.18, or for any top-solid nonwaterlogged block in 1.18+. This library cannot model individual blocks, so the search relies on heuristics such as biomes and climate-dependent world heights. Alternatively, we can simply use `estimateSpawn()` and terminate the search after the first biome/climate check under the assumption that grass/a top-solid nonwaterlogged block is nearby.
 
 
 ```C

--- a/biomenoise.c
+++ b/biomenoise.c
@@ -405,6 +405,12 @@ static int getEndBiome(int hx, int hz, const uint16_t *hmap, int hw)
         uint32_t u;
 
         // force unroll for(i=0;i<25;i++) in a cross compatible way
+        #ifdef x5
+            #undef x5
+        #endif
+        #ifdef for25
+            #undef for25
+        #endif
         #define x5(i,x)    { x; i++; x; i++; x; i++; x; i++; x; i++; }
         #define for25(i,x) { i = 0; x5(i,x) x5(i,x) x5(i,x) x5(i,x) x5(i,x) }
         for25(i,

--- a/biomenoise.c
+++ b/biomenoise.c
@@ -405,12 +405,6 @@ static int getEndBiome(int hx, int hz, const uint16_t *hmap, int hw)
         uint32_t u;
 
         // force unroll for(i=0;i<25;i++) in a cross compatible way
-        #ifdef x5
-            #undef x5
-        #endif
-        #ifdef for25
-            #undef for25
-        #endif
         #define x5(i,x)    { x; i++; x; i++; x; i++; x; i++; x; i++; }
         #define for25(i,x) { i = 0; x5(i,x) x5(i,x) x5(i,x) x5(i,x) x5(i,x) }
         for25(i,

--- a/carver.c
+++ b/carver.c
@@ -5,45 +5,18 @@
 #include <string.h>
 
 // https://c-faq.com/misc/bitsets.html
-#ifdef BITMASK
-    #undef BITMASK
-#endif
 #define BITMASK(b) (1 << ((b) % CHAR_BIT))
-#ifdef BITSLOT
-    #undef BITSLOT
-#endif
 #define BITSLOT(b) ((b) / CHAR_BIT)
-#ifdef BITSET
-    #undef BITSET
-#endif
 #define BITSET(a, b) ((a)[BITSLOT(b)] |= BITMASK(b))
-#ifdef BITCLEAR
-    #undef BITCLEAR
-#endif
 #define BITCLEAR(a, b) ((a)[BITSLOT(b)] &= ~BITMASK(b))
-#ifdef BITTEST
-    #undef BITTEST
-#endif
 #define BITTEST(a, b) ((a)[BITSLOT(b)] & BITMASK(b))
-#ifdef BITNSLOTS
-    #undef BITNSLOTS
-#endif
 #define BITNSLOTS(nb) ((nb + CHAR_BIT - 1) / CHAR_BIT)
 
-#ifdef PI
-    #undef PI
-#endif
 #define PI 3.14159265358979323846
 
-// WARNING: This is dangerous because a/b can be evaluated multiple times.
-// E.g. MIN(nextInt(&rnd, 5), 5) will call nextInt(&rnd, 5) twice instead of once.
-#ifdef MIN
-    #undef MIN
-#endif
+// WARNING: Be wary of multiple evaluation.
 #define MIN(a, b) ((a) < (b) ? (a) : (b))
-#ifdef MAX
-    #undef MAX
-#endif
+// WARNING: Be wary of multiple evaluation.
 #define MAX(a, b) ((a) > (b) ? (a) : (b))
 
 int getCanyonCarverConfig(int canyonCarverType, int mc, CanyonCarverConfig* cconf) {
@@ -200,7 +173,7 @@ static inline int shouldSkipCanyonCarve(double relativeX, double relativeY, doub
     return (relativeX * relativeX + relativeZ * relativeZ) * ((float*) widthFactors)[i - 1] + relativeY * relativeY / 6.0 >= 1.0;
 }
 
-static inline int shouldSkipCaveCarve(double relativeX, double relativeY, double relativeZ, int y, int worldMinY, /* double* */ void* minRelativeY) {
+static inline int shouldSkipCaveCarve(double relativeX, double relativeY, double relativeZ, int, int, /* double* */ void* minRelativeY) {
     return relativeY <= *(double*) minRelativeY ? 1 : relativeX * relativeX + relativeY * relativeY + relativeZ * relativeZ >= 1.0;
 }
 

--- a/carver.c
+++ b/carver.c
@@ -173,7 +173,9 @@ static inline int shouldSkipCanyonCarve(double relativeX, double relativeY, doub
     return (relativeX * relativeX + relativeZ * relativeZ) * ((float*) widthFactors)[i - 1] + relativeY * relativeY / 6.0 >= 1.0;
 }
 
-static inline int shouldSkipCaveCarve(double relativeX, double relativeY, double relativeZ, int, int, /* double* */ void* minRelativeY) {
+static inline int shouldSkipCaveCarve(double relativeX, double relativeY, double relativeZ, int unused1_, int unused2_, /* double* */ void* minRelativeY) {
+    (void)(unused1_); // Unused
+    (void)(unused2_); // Unused
     return relativeY <= *(double*) minRelativeY ? 1 : relativeX * relativeX + relativeY * relativeY + relativeZ * relativeZ >= 1.0;
 }
 

--- a/carver.c
+++ b/carver.c
@@ -5,16 +5,45 @@
 #include <string.h>
 
 // https://c-faq.com/misc/bitsets.html
+#ifdef BITMASK
+    #undef BITMASK
+#endif
 #define BITMASK(b) (1 << ((b) % CHAR_BIT))
+#ifdef BITSLOT
+    #undef BITSLOT
+#endif
 #define BITSLOT(b) ((b) / CHAR_BIT)
+#ifdef BITSET
+    #undef BITSET
+#endif
 #define BITSET(a, b) ((a)[BITSLOT(b)] |= BITMASK(b))
+#ifdef BITCLEAR
+    #undef BITCLEAR
+#endif
 #define BITCLEAR(a, b) ((a)[BITSLOT(b)] &= ~BITMASK(b))
+#ifdef BITTEST
+    #undef BITTEST
+#endif
 #define BITTEST(a, b) ((a)[BITSLOT(b)] & BITMASK(b))
+#ifdef BITNSLOTS
+    #undef BITNSLOTS
+#endif
 #define BITNSLOTS(nb) ((nb + CHAR_BIT - 1) / CHAR_BIT)
 
+#ifdef PI
+    #undef PI
+#endif
 #define PI 3.14159265358979323846
 
+// WARNING: This is dangerous because a/b can be evaluated multiple times.
+// E.g. MIN(nextInt(&rnd, 5), 5) will call nextInt(&rnd, 5) twice instead of once.
+#ifdef MIN
+    #undef MIN
+#endif
 #define MIN(a, b) ((a) < (b) ? (a) : (b))
+#ifdef MAX
+    #undef MAX
+#endif
 #define MAX(a, b) ((a) > (b) ? (a) : (b))
 
 int getCanyonCarverConfig(int canyonCarverType, int mc, CanyonCarverConfig* cconf) {

--- a/features/ore.c
+++ b/features/ore.c
@@ -5,45 +5,18 @@
 #include <string.h>
 
 // https://c-faq.com/misc/bitsets.html
-#ifdef BITMASK
-    #undef BITMASK
-#endif
 #define BITMASK(b) (1 << ((b) % CHAR_BIT))
-#ifdef BITSLOT
-    #undef BITSLOT
-#endif
 #define BITSLOT(b) ((b) / CHAR_BIT)
-#ifdef BITSET
-    #undef BITSET
-#endif
 #define BITSET(a, b) ((a)[BITSLOT(b)] |= BITMASK(b))
-#ifdef BITCLEAR
-    #undef BITCLEAR
-#endif
 #define BITCLEAR(a, b) ((a)[BITSLOT(b)] &= ~BITMASK(b))
-#ifdef BITTEST
-    #undef BITTEST
-#endif
 #define BITTEST(a, b) ((a)[BITSLOT(b)] & BITMASK(b))
-#ifdef BITNSLOTS
-    #undef BITNSLOTS
-#endif
 #define BITNSLOTS(nb) ((nb + CHAR_BIT - 1) / CHAR_BIT)
 
-#ifdef PI
-    #undef PI
-#endif
 #define PI 3.14159265358979323846
 
-// WARNING: This is dangerous because a/b can be evaluated multiple times.
-// E.g. MIN(nextInt(&rnd, 5), 5) will call nextInt(&rnd, 5) twice instead of once.
-#ifdef MIN
-    #undef MIN
-#endif
+// WARNING: Be wary of multiple evaluation.
 #define MIN(a, b) ((a) < (b) ? (a) : (b))
-#ifdef MAX
-    #undef MAX
-#endif
+// WARNING: Be wary of multiple evaluation.
 #define MAX(a, b) ((a) > (b) ? (a) : (b))
 
 int getOreConfig(int oreType, int mc, int biomeID, OreConfig *oconf)

--- a/features/ore.c
+++ b/features/ore.c
@@ -5,16 +5,45 @@
 #include <string.h>
 
 // https://c-faq.com/misc/bitsets.html
+#ifdef BITMASK
+    #undef BITMASK
+#endif
 #define BITMASK(b) (1 << ((b) % CHAR_BIT))
+#ifdef BITSLOT
+    #undef BITSLOT
+#endif
 #define BITSLOT(b) ((b) / CHAR_BIT)
+#ifdef BITSET
+    #undef BITSET
+#endif
 #define BITSET(a, b) ((a)[BITSLOT(b)] |= BITMASK(b))
+#ifdef BITCLEAR
+    #undef BITCLEAR
+#endif
 #define BITCLEAR(a, b) ((a)[BITSLOT(b)] &= ~BITMASK(b))
+#ifdef BITTEST
+    #undef BITTEST
+#endif
 #define BITTEST(a, b) ((a)[BITSLOT(b)] & BITMASK(b))
+#ifdef BITNSLOTS
+    #undef BITNSLOTS
+#endif
 #define BITNSLOTS(nb) ((nb + CHAR_BIT - 1) / CHAR_BIT)
 
+#ifdef PI
+    #undef PI
+#endif
 #define PI 3.14159265358979323846
 
+// WARNING: This is dangerous because a/b can be evaluated multiple times.
+// E.g. MIN(nextInt(&rnd, 5), 5) will call nextInt(&rnd, 5) twice instead of once.
+#ifdef MIN
+    #undef MIN
+#endif
 #define MIN(a, b) ((a) < (b) ? (a) : (b))
+#ifdef MAX
+    #undef MAX
+#endif
 #define MAX(a, b) ((a) > (b) ? (a) : (b))
 
 int getOreConfig(int oreType, int mc, int biomeID, OreConfig *oconf)

--- a/features/ore.h
+++ b/features/ore.h
@@ -87,24 +87,32 @@ static inline int providerRange(RandomSource *rnd, const int bottomOffset, const
 }
 
 // <=1.16.5
-static inline int providerDepthAverage(RandomSource *rnd, const int baseline, const int spread, int) {
+static inline int providerDepthAverage(RandomSource *rnd, const int baseline, const int spread, int unused_) {
+    (void)(unused_); // Unused
     int a = absNextInt(rnd, spread);
     int b = absNextInt(rnd, spread);
     return a + b - spread + baseline;
 }
 
 // <=1.16.5
-static inline int providerEmeraldOre(RandomSource *rnd, int, int, int) {
+static inline int providerEmeraldOre(RandomSource *rnd, int unused1_, int unused2_, int unused3_) {
+    (void)(unused1_); // Unused
+    (void)(unused2_); // Unused
+    (void)(unused3_); // Unused
     return absNextInt(rnd, 28) + 4;
 }
 
 // <=1.16.5
-static inline int providerMagmaOre(RandomSource *rnd, int, int, int) {
+static inline int providerMagmaOre(RandomSource *rnd, int unused1_, int unused2_, int unused3_) {
+    (void)(unused1_); // Unused
+    (void)(unused2_); // Unused
+    (void)(unused3_); // Unused
     return 32 - 5 + absNextInt(rnd, 10);
 }
 
 // >=1.17
-static inline int providerUniformRange(RandomSource *rnd, const int minOffset, const int maxOffset, int) {
+static inline int providerUniformRange(RandomSource *rnd, const int minOffset, const int maxOffset, int unused_) {
+    (void)(unused_); // Unused
     if (minOffset > maxOffset) {
         return minOffset;
     }
@@ -112,7 +120,8 @@ static inline int providerUniformRange(RandomSource *rnd, const int minOffset, c
 }
 
 // >=1.17
-static inline int providerTriangleRange(RandomSource *rnd, const int minOffset, const int maxOffset, int) {
+static inline int providerTriangleRange(RandomSource *rnd, const int minOffset, const int maxOffset, int unused_) {
+    (void)(unused_); // Unused
     if (minOffset > maxOffset) {
         return minOffset;
     }

--- a/features/ore.h
+++ b/features/ore.h
@@ -87,24 +87,24 @@ static inline int providerRange(RandomSource *rnd, const int bottomOffset, const
 }
 
 // <=1.16.5
-static inline int providerDepthAverage(RandomSource *rnd, const int baseline, const int spread, const int h3) {
+static inline int providerDepthAverage(RandomSource *rnd, const int baseline, const int spread, int) {
     int a = absNextInt(rnd, spread);
     int b = absNextInt(rnd, spread);
     return a + b - spread + baseline;
 }
 
 // <=1.16.5
-static inline int providerEmeraldOre(RandomSource *rnd, int h1, int h2, int h3) {
+static inline int providerEmeraldOre(RandomSource *rnd, int, int, int) {
     return absNextInt(rnd, 28) + 4;
 }
 
 // <=1.16.5
-static inline int providerMagmaOre(RandomSource *rnd, int h1, int h2, int h3) {
+static inline int providerMagmaOre(RandomSource *rnd, int, int, int) {
     return 32 - 5 + absNextInt(rnd, 10);
 }
 
 // >=1.17
-static inline int providerUniformRange(RandomSource *rnd, const int minOffset, const int maxOffset, const int h3) {
+static inline int providerUniformRange(RandomSource *rnd, const int minOffset, const int maxOffset, int) {
     if (minOffset > maxOffset) {
         return minOffset;
     }
@@ -112,7 +112,7 @@ static inline int providerUniformRange(RandomSource *rnd, const int minOffset, c
 }
 
 // >=1.17
-static inline int providerTriangleRange(RandomSource *rnd, const int minOffset, const int maxOffset, const int h3) {
+static inline int providerTriangleRange(RandomSource *rnd, const int minOffset, const int maxOffset, int) {
     if (minOffset > maxOffset) {
         return minOffset;
     }

--- a/features/stronghold.c
+++ b/features/stronghold.c
@@ -2,7 +2,15 @@
 
 #include <string.h>
 
+// WARNING: This is dangerous because a/b can be evaluated multiple times.
+// E.g. MIN(nextInt(&rnd, 5), 5) will call nextInt(&rnd, 5) twice instead of once.
+#ifdef MIN
+    #undef MIN
+#endif
 #define MIN(a, b) ((a) < (b) ? (a) : (b))
+#ifdef MAX
+    #undef MAX
+#endif
 #define MAX(a, b) ((a) > (b) ? (a) : (b))
 
 STRUCT(StrongholdPieceEnv) {

--- a/features/stronghold.c
+++ b/features/stronghold.c
@@ -2,15 +2,9 @@
 
 #include <string.h>
 
-// WARNING: This is dangerous because a/b can be evaluated multiple times.
-// E.g. MIN(nextInt(&rnd, 5), 5) will call nextInt(&rnd, 5) twice instead of once.
-#ifdef MIN
-    #undef MIN
-#endif
+// WARNING: Be wary of multiple evaluation.
 #define MIN(a, b) ((a) < (b) ? (a) : (b))
-#ifdef MAX
-    #undef MAX
-#endif
+// WARNING: Be wary of multiple evaluation.
 #define MAX(a, b) ((a) > (b) ? (a) : (b))
 
 STRUCT(StrongholdPieceEnv) {

--- a/features/stronghold.c
+++ b/features/stronghold.c
@@ -96,7 +96,7 @@ static int addStrongholdPiece(StrongholdPieceEnv *env, int typ, int x, int y, in
     case SH_PORTAL_ROOM:
         offset = stronghold_info[typ].offset; size = stronghold_info[typ].size; break;
     case SH_LIBRARY:
-        offset = (Pos3) stronghold_info[typ].offset; size = (Pos3) stronghold_info[typ].size;
+        offset = stronghold_info[typ].offset; size = stronghold_info[typ].size;
         orientBox(pos, offset, size, facing, &b0, &b1);
         if (b0.y > 10 && !hasCollision(env, b0, b1)) {
             goto L_box_end;
@@ -104,7 +104,7 @@ static int addStrongholdPiece(StrongholdPieceEnv *env, int typ, int x, int y, in
         size.y = 6;
         break;
     case SH_FILLER_CORRIDOR:
-        offset = (Pos3) stronghold_info[typ].offset; size = (Pos3) stronghold_info[typ].size;
+        offset = stronghold_info[typ].offset; size = stronghold_info[typ].size;
         orientBox(pos, offset, size, facing, &b0, &b1);
         Piece *p = hasCollision(env, b0, b1);
         if (!p) {
@@ -250,13 +250,17 @@ static void generateSmallDoorChildForward(StrongholdPieceEnv *env, Piece *piece,
     // WEST and EAST are swapped on old versions
     switch (piece->rot) {
     case 0: // facing 2
-        return extendStronghold(env, piece, piece->bb0.x + offx, piece->bb0.y + offy, piece->bb0.z - 1, 0);
+        extendStronghold(env, piece, piece->bb0.x + offx, piece->bb0.y + offy, piece->bb0.z - 1, 0);
+        return;
     case 2: // facing 0
-        return extendStronghold(env, piece, piece->bb0.x + offx, piece->bb0.y + offy, piece->bb1.z + 1, 2);
+        extendStronghold(env, piece, piece->bb0.x + offx, piece->bb0.y + offy, piece->bb1.z + 1, 2);
+        return;
     case 3: // facing 1
-        return extendStronghold(env, piece, piece->bb0.x - 1, piece->bb0.y + offy, piece->bb0.z + offx, 3);
+        extendStronghold(env, piece, piece->bb0.x - 1, piece->bb0.y + offy, piece->bb0.z + offx, 3);
+        return;
     case 1: // facing 3
-        return extendStronghold(env, piece, piece->bb1.x + 1, piece->bb0.y + offy, piece->bb0.z + offx, 1);
+        extendStronghold(env, piece, piece->bb1.x + 1, piece->bb0.y + offy, piece->bb0.z + offx, 1);
+        return;
     default: UNREACHABLE();
     }
 }
@@ -265,10 +269,12 @@ static void generateSmallDoorChildLeft(StrongholdPieceEnv *env, Piece *piece, in
     switch (piece->rot) {
     case 0:
     case 2:
-        return extendStronghold(env, piece, piece->bb0.x - 1, piece->bb0.y + offy, piece->bb0.z + offz, 3);
+        extendStronghold(env, piece, piece->bb0.x - 1, piece->bb0.y + offy, piece->bb0.z + offz, 3);
+        return;
     case 3:
     case 1:
-        return extendStronghold(env, piece, piece->bb0.x + offz, piece->bb0.y + offy, piece->bb0.z - 1, 0);
+        extendStronghold(env, piece, piece->bb0.x + offz, piece->bb0.y + offy, piece->bb0.z - 1, 0);
+        return;
     default: UNREACHABLE();
     }
 }
@@ -277,10 +283,12 @@ static void generateSmallDoorChildRight(StrongholdPieceEnv *env, Piece *piece, i
     switch (piece->rot) {
     case 0:
     case 2:
-        return extendStronghold(env, piece, piece->bb1.x + 1, piece->bb0.y + offy, piece->bb0.z + offz, 1);
+        extendStronghold(env, piece, piece->bb1.x + 1, piece->bb0.y + offy, piece->bb0.z + offz, 1);
+        return;
     case 3:
     case 1:
-        return extendStronghold(env, piece, piece->bb0.x + offz, piece->bb0.y + offy, piece->bb1.z + 1, 2);
+        extendStronghold(env, piece, piece->bb0.x + offz, piece->bb0.y + offy, piece->bb1.z + 1, 2);
+        return;
     default: UNREACHABLE();
     }
 }

--- a/finders.c
+++ b/finders.c
@@ -12,9 +12,20 @@
 #include <float.h>
 #include <math.h>
 
+#ifdef PI
+    #undef PI
+#endif
 #define PI 3.14159265358979323846
 
+// WARNING: This is dangerous because a/b can be evaluated multiple times.
+// E.g. MIN(nextInt(&rnd, 5), 5) will call nextInt(&rnd, 5) twice instead of once.
+#ifdef MIN
+    #undef MIN
+#endif
 #define MIN(a, b) ((a) < (b) ? (a) : (b))
+#ifdef MAX
+    #undef MAX
+#endif
 #define MAX(a, b) ((a) > (b) ? (a) : (b))
 
 
@@ -1144,9 +1155,9 @@ int nextStronghold(StrongholdIter *sh, const Generator *g)
     {
         return 0;
     }
-    // staircase is located at (4, 4) in chunk
-    sh->pos.x = (sh->pos.x & ~15) + 4;
-    sh->pos.z = (sh->pos.z & ~15) + 4;
+    // staircase is located at corner of chunk
+    sh->pos.x = (sh->pos.x & ~15);
+    sh->pos.z = (sh->pos.z & ~15);
 
     sh->ringidx++;
     sh->angle += 2 * PI / sh->ringmax;
@@ -1252,9 +1263,9 @@ Pos findFittestPos(const Generator *g)
     uint64_t fitness = calcFitness(g, 0, 0);
     findFittest(g, &spawn, &fitness, 2048.0, 512.0);
     findFittest(g, &spawn, &fitness, 512.0, 32.0);
-    // center of chunk
-    spawn.x = (spawn.x & ~15) + 8;
-    spawn.z = (spawn.z & ~15) + 8;
+    // corner of chunk
+    spawn.x = (spawn.x & ~15);
+    spawn.z = (spawn.z & ~15);
     return spawn;
 }
 
@@ -1288,7 +1299,7 @@ Pos estimateSpawn(const Generator *g, uint64_t *rng)
         setSeed(&s, g->seed);
         spawn = locateBiome(g, 0, 63, 0, 256, spawn_biomes, 0, &s, &found);
         if (!found)
-            spawn.x = spawn.z = 8;
+            spawn.x = spawn.z = 8*(g->mc >= MC_1_9);
         if (rng)
             *rng = s;
     }
@@ -6058,6 +6069,12 @@ L_end:
     return err;
 }
 
+#ifdef IMIN
+    #undef IMIN
+#endif
+#ifdef IMAX
+    #undef IMAX
+#endif
 #define IMIN INT_MIN
 #define IMAX INT_MAX
 static const int g_biome_para_range_18[][13] = {

--- a/finders.c
+++ b/finders.c
@@ -12,20 +12,11 @@
 #include <float.h>
 #include <math.h>
 
-#ifdef PI
-    #undef PI
-#endif
 #define PI 3.14159265358979323846
 
-// WARNING: This is dangerous because a/b can be evaluated multiple times.
-// E.g. MIN(nextInt(&rnd, 5), 5) will call nextInt(&rnd, 5) twice instead of once.
-#ifdef MIN
-    #undef MIN
-#endif
+// WARNING: Be wary of multiple evaluation.
 #define MIN(a, b) ((a) < (b) ? (a) : (b))
-#ifdef MAX
-    #undef MAX
-#endif
+// WARNING: Be wary of multiple evaluation.
 #define MAX(a, b) ((a) > (b) ? (a) : (b))
 
 
@@ -1155,9 +1146,9 @@ int nextStronghold(StrongholdIter *sh, const Generator *g)
     {
         return 0;
     }
-    // staircase is located at corner of chunk
-    sh->pos.x = (sh->pos.x & ~15);
-    sh->pos.z = (sh->pos.z & ~15);
+    // staircase is located at (4, 4) in chunk
+    sh->pos.x = (sh->pos.x & ~15) + 4;
+    sh->pos.z = (sh->pos.z & ~15) + 4;
 
     sh->ringidx++;
     sh->angle += 2 * PI / sh->ringmax;
@@ -1264,8 +1255,8 @@ Pos findFittestPos(const Generator *g)
     findFittest(g, &spawn, &fitness, 2048.0, 512.0);
     findFittest(g, &spawn, &fitness, 512.0, 32.0);
     // corner of chunk
-    spawn.x = (spawn.x & ~15);
-    spawn.z = (spawn.z & ~15);
+    spawn.x &= ~15;
+    spawn.z &= ~15;
     return spawn;
 }
 
@@ -1299,7 +1290,7 @@ Pos estimateSpawn(const Generator *g, uint64_t *rng)
         setSeed(&s, g->seed);
         spawn = locateBiome(g, 0, 63, 0, 256, spawn_biomes, 0, &s, &found);
         if (!found)
-            spawn.x = spawn.z = 8*(g->mc >= MC_1_9);
+            spawn.x = spawn.z = 8 * (g->mc >= MC_1_9);
         if (rng)
             *rng = s;
     }
@@ -6069,12 +6060,6 @@ L_end:
     return err;
 }
 
-#ifdef IMIN
-    #undef IMIN
-#endif
-#ifdef IMAX
-    #undef IMAX
-#endif
 #define IMIN INT_MIN
 #define IMAX INT_MAX
 static const int g_biome_para_range_18[][13] = {

--- a/finders.h
+++ b/finders.h
@@ -11,7 +11,7 @@ extern "C"
 #endif
 
 #ifdef MASK48
-    #undef MASK48
+#undef MASK48
 #endif
 #define MASK48 (((int64_t)1 << 48) - 1)
 
@@ -461,8 +461,7 @@ int32_t getOreVeinBlockAt(int x, int y, int z, OreVeinParameters* params);
 // Random providers
 //==============================================================================
 
-static inline int providerUniformIntBetween(uint64_t* rnd, int minInclusive, int maxInclusive, int unused_) {
-    (void)(unused_); // Unused
+static inline int providerUniformIntBetween(uint64_t* rnd, int minInclusive, int maxInclusive, int) {
     if (minInclusive > maxInclusive) {
         return minInclusive;
     }
@@ -477,9 +476,7 @@ static inline int providerBiasedToBottom(uint64_t* rnd, int minInclusive, int ma
     return nextInt(rnd, k + inner) + minInclusive;
 }
 
-static inline float providerConstantFloat(uint64_t* unused1_, float value, float unused2_) {
-    (void)(unused1_); // Unused
-    (void)(unused2_); // Unused
+static inline float providerConstantFloat(uint64_t*, float value, float) {
     return value;
 }
 

--- a/finders.h
+++ b/finders.h
@@ -10,6 +10,9 @@ extern "C"
 {
 #endif
 
+#ifdef MASK48
+    #undef MASK48
+#endif
 #define MASK48 (((int64_t)1 << 48) - 1)
 
 enum StructureType
@@ -458,7 +461,8 @@ int32_t getOreVeinBlockAt(int x, int y, int z, OreVeinParameters* params);
 // Random providers
 //==============================================================================
 
-static inline int providerUniformIntBetween(uint64_t* rnd, int minInclusive, int maxInclusive, int a3) {
+static inline int providerUniformIntBetween(uint64_t* rnd, int minInclusive, int maxInclusive, int unused_) {
+    (void)(unused_); // Unused
     if (minInclusive > maxInclusive) {
         return minInclusive;
     }
@@ -473,7 +477,9 @@ static inline int providerBiasedToBottom(uint64_t* rnd, int minInclusive, int ma
     return nextInt(rnd, k + inner) + minInclusive;
 }
 
-static inline float providerConstantFloat(uint64_t* rnd, float value, float a2) {
+static inline float providerConstantFloat(uint64_t* unused1_, float value, float unused2_) {
+    (void)(unused1_); // Unused
+    (void)(unused2_); // Unused
     return value;
 }
 

--- a/finders.h
+++ b/finders.h
@@ -461,7 +461,8 @@ int32_t getOreVeinBlockAt(int x, int y, int z, OreVeinParameters* params);
 // Random providers
 //==============================================================================
 
-static inline int providerUniformIntBetween(uint64_t* rnd, int minInclusive, int maxInclusive, int) {
+static inline int providerUniformIntBetween(uint64_t* rnd, int minInclusive, int maxInclusive, int unused_) {
+    (void)(unused_);
     if (minInclusive > maxInclusive) {
         return minInclusive;
     }
@@ -476,7 +477,9 @@ static inline int providerBiasedToBottom(uint64_t* rnd, int minInclusive, int ma
     return nextInt(rnd, k + inner) + minInclusive;
 }
 
-static inline float providerConstantFloat(uint64_t*, float value, float) {
+static inline float providerConstantFloat(uint64_t* unused1_, float value, float unused2_) {
+    (void)(unused1_);
+    (void)(unused2_);
     return value;
 }
 

--- a/layers.h
+++ b/layers.h
@@ -5,6 +5,9 @@
 #include "biomes.h"
 
 
+#ifdef LAYER_INIT_SHA
+    #undef LAYER_INIT_SHA
+#endif
 #define LAYER_INIT_SHA          (~0ULL)
 
 

--- a/layers.h
+++ b/layers.h
@@ -6,7 +6,7 @@
 
 
 #ifdef LAYER_INIT_SHA
-    #undef LAYER_INIT_SHA
+#undef LAYER_INIT_SHA
 #endif
 #define LAYER_INIT_SHA          (~0ULL)
 

--- a/loot/logging.h
+++ b/loot/logging.h
@@ -4,7 +4,7 @@
 #include <stdio.h>
 
 #ifdef LOG_ERROR
-    #undef LOG_ERROR
+#undef LOG_ERROR
 #endif
 #define LOG_ERROR(message) log_error(message, __FILE__, __LINE__)
 static inline void log_error(const char* message, const char* file, const int line) {

--- a/loot/logging.h
+++ b/loot/logging.h
@@ -3,6 +3,9 @@
 
 #include <stdio.h>
 
+#ifdef LOG_ERROR
+    #undef LOG_ERROR
+#endif
 #define LOG_ERROR(message) log_error(message, __FILE__, __LINE__)
 static inline void log_error(const char* message, const char* file, const int line) {
     fprintf(stderr, "%s:%d - %s\n", file, line, message);

--- a/loot/loot_functions.c
+++ b/loot/loot_functions.c
@@ -125,8 +125,9 @@ static void set_count_uniform_function(RandomSource* rand, ItemStack* is, const 
     is->count = cnt;
 }
 
-static void set_count_constant_function(RandomSource*, ItemStack* is, const void* params)
+static void set_count_constant_function(RandomSource* unused_, ItemStack* is, const void* params)
 {
+    (void)(unused_); // Unused
     const int* params_int = (const int*)params;
     is->count = params_int[0];
 }
@@ -146,8 +147,9 @@ static void set_effect_function(RandomSource* rand, ItemStack* is, const void* p
     is->mob_effect.duration = duration;
 }
 
-static void set_potion_function(RandomSource*, ItemStack* is, const void* params)
+static void set_potion_function(RandomSource* unused_, ItemStack* is, const void* params)
 {
+    (void)(unused_); // Unused
     int* varparams_int = (int*)params;
     Potion potion = *(Potion *)varparams_int;
     // currently only buried treasures and abandoned camps use potions, where each potion has exactly one mob effect
@@ -156,19 +158,25 @@ static void set_potion_function(RandomSource*, ItemStack* is, const void* params
     }
 }
 
-static void skip_n_calls_function(RandomSource* rand, ItemStack*, const void* params)
+static void skip_n_calls_function(RandomSource* rand, ItemStack* unused_, const void* params)
 {
+    (void)(unused_); // Unused
     const int* params_int = (const int*)params;
     absSkipN(rand, params_int[0]);
 }
 
-static void skip_one_call_function(RandomSource* rand, ItemStack*, const void*)
+static void skip_one_call_function(RandomSource* rand, ItemStack* unused1_, const void* unused2_)
 {
+    (void)(unused1_); // Unused
+    (void)(unused2_); // Unused
     absSkipN(rand, 1);
 }
 
-static void no_op_function(RandomSource*, ItemStack*, const void*)
+static void no_op_function(RandomSource* unused1_, ItemStack* unused2_, const void* unused3_)
 {
+    (void)(unused1_); // Unused
+    (void)(unused2_); // Unused
+    (void)(unused3_); // Unused
     // do nothing
 }
 
@@ -363,7 +371,8 @@ static void enchant_with_levels_function(RandomSource* rand, ItemStack* is, cons
     }
 }
 
-static void set_enchantments_function(RandomSource*, ItemStack* is, const void* params) {
+static void set_enchantments_function(RandomSource* unused_, ItemStack* is, const void* params) {
+    (void)(unused_); // Unused
     int* params_int = (int*)params;
     const int length = params_int[0];
 

--- a/loot/loot_functions.c
+++ b/loot/loot_functions.c
@@ -125,7 +125,7 @@ static void set_count_uniform_function(RandomSource* rand, ItemStack* is, const 
     is->count = cnt;
 }
 
-static void set_count_constant_function(RandomSource* rand, ItemStack* is, const void* params)
+static void set_count_constant_function(RandomSource*, ItemStack* is, const void* params)
 {
     const int* params_int = (const int*)params;
     is->count = params_int[0];
@@ -146,7 +146,7 @@ static void set_effect_function(RandomSource* rand, ItemStack* is, const void* p
     is->mob_effect.duration = duration;
 }
 
-static void set_potion_function(RandomSource* rand, ItemStack* is, const void* params)
+static void set_potion_function(RandomSource*, ItemStack* is, const void* params)
 {
     int* varparams_int = (int*)params;
     Potion potion = *(Potion *)varparams_int;
@@ -156,18 +156,18 @@ static void set_potion_function(RandomSource* rand, ItemStack* is, const void* p
     }
 }
 
-static void skip_n_calls_function(RandomSource* rand, ItemStack* is, const void* params)
+static void skip_n_calls_function(RandomSource* rand, ItemStack*, const void* params)
 {
     const int* params_int = (const int*)params;
     absSkipN(rand, params_int[0]);
 }
 
-static void skip_one_call_function(RandomSource* rand, ItemStack* is, const void* params)
+static void skip_one_call_function(RandomSource* rand, ItemStack*, const void*)
 {
     absSkipN(rand, 1);
 }
 
-static void no_op_function(RandomSource* rand, ItemStack* is, const void* params)
+static void no_op_function(RandomSource*, ItemStack*, const void*)
 {
     // do nothing
 }
@@ -363,7 +363,7 @@ static void enchant_with_levels_function(RandomSource* rand, ItemStack* is, cons
     }
 }
 
-static void set_enchantments_function(RandomSource* rand, ItemStack* is, const void* params) {
+static void set_enchantments_function(RandomSource*, ItemStack* is, const void* params) {
     int* params_int = (int*)params;
     const int length = params_int[0];
 
@@ -533,6 +533,7 @@ static int is_applicable(const Enchantment enchantment, const ItemType item, con
 
     case LUNGE:
         return item == SPEAR;
+    default: UNREACHABLE();
     }
 
     return 0;
@@ -718,6 +719,7 @@ static int test_effective_level(const Enchantment enchantment, const int i, cons
         if ((n < 15 + (i - 1) * 9) || (n > 65 + (i - 1) * 9))
             return 0;
         break;
+    default: UNREACHABLE();
     }
 
     return 1;

--- a/loot/loot_functions.h
+++ b/loot/loot_functions.h
@@ -278,7 +278,7 @@ STRUCT(LootFunction) {
 // ----------------------------------------------------------------------------------------
 // Roll count choice functions
 
-static inline int roll_count_constant(RandomSource* rand, const int min, const int max)
+static inline int roll_count_constant(RandomSource*, const int min, int)
 {
     return min;
 }

--- a/loot/loot_functions.h
+++ b/loot/loot_functions.h
@@ -278,8 +278,9 @@ STRUCT(LootFunction) {
 // ----------------------------------------------------------------------------------------
 // Roll count choice functions
 
-static inline int roll_count_constant(RandomSource*, const int min, int)
+static inline int roll_count_constant(RandomSource*, const int min, int unused_)
 {
+    (void)(unused_); // Unused
     return min;
 }
 

--- a/loot/loot_table_context.c
+++ b/loot/loot_table_context.c
@@ -57,7 +57,6 @@ static void generate_subtable_loot(LootTableContext* context, int subtable_index
 
 static void generate_subtable_loot(LootTableContext* context, int subtable_index)
 {
-    LootPool* pool = &(context->loot_pools[context->subtable_pool_offset[subtable_index]]);
     int pool_count = context->subtable_pool_count[subtable_index];
 
     for (int i = 0; i < pool_count; i++)

--- a/loot/loot_tables/_gen_c_loot_tables.py
+++ b/loot/loot_tables/_gen_c_loot_tables.py
@@ -497,15 +497,14 @@ def gen_c_loot_table(c_file_path: Path, context: LootTableContext) -> str:
         """)
 
     for pool_idx, loot_pool in enumerate(context.loot_pools):
-        file_content += f"    LootPool* loot_pool__{pool_idx} = &(context.loot_pools[{pool_idx}]);\n"
+        functions = [function for entry in loot_pool.entries for function in entry.functions]
+        if loot_pool.conditions or functions:
+            file_content += f"    LootPool* loot_pool__{pool_idx} = &(context.loot_pools[{pool_idx}]);\n"
         for condition_idx, condition in enumerate(loot_pool.conditions):
             file_content += f"    {condition.to_function_call(f"&(loot_pool__{pool_idx}->conditions[{condition_idx}])", context.version)};\n"
-        i = 0
-        for entry in loot_pool.entries:
-            for function in entry.functions:
-                function_str = f"&(loot_pool__{pool_idx}->loot_functions[{i}])"
-                file_content += f"    {function.to_function_call(function_str, context.version)};\n"
-                i += 1
+        for i, function in enumerate(functions):
+            function_str = f"&(loot_pool__{pool_idx}->loot_functions[{i}])"
+            file_content += f"    {function.to_function_call(function_str, context.version)};\n"
 
     file_content += f"}}\n"
 

--- a/loot/loot_tables/chests/bastion_bridge_1_20.c
+++ b/loot/loot_tables/chests/bastion_bridge_1_20.c
@@ -156,8 +156,6 @@ static void create_loot_functions() {
     create_set_count(&(loot_pool__2->loot_functions[2]), 5, 17);
     create_set_count(&(loot_pool__2->loot_functions[3]), 2, 6);
     create_set_count(&(loot_pool__2->loot_functions[4]), 2, 6);
-    LootPool* loot_pool__3 = &(context.loot_pools[3]);
-    LootPool* loot_pool__4 = &(context.loot_pools[4]);
 }
 
 LootTableContext* init_bastion_bridge_1_20() {

--- a/loot/loot_tables/chests/bastion_other_1_20.c
+++ b/loot/loot_tables/chests/bastion_other_1_20.c
@@ -172,8 +172,6 @@ static void create_loot_functions() {
     create_set_count(&(loot_pool__2->loot_functions[7]), 4, 6);
     create_set_count(&(loot_pool__2->loot_functions[8]), 5, 17);
     create_set_count(&(loot_pool__2->loot_functions[9]), 1, 1);
-    LootPool* loot_pool__3 = &(context.loot_pools[3]);
-    LootPool* loot_pool__4 = &(context.loot_pools[4]);
 }
 
 LootTableContext* init_bastion_other_1_20() {

--- a/loot/loot_tables/chests/bastion_other_1_21_1.c
+++ b/loot/loot_tables/chests/bastion_other_1_21_1.c
@@ -172,8 +172,6 @@ static void create_loot_functions() {
     create_set_count(&(loot_pool__2->loot_functions[7]), 4, 6);
     create_set_count(&(loot_pool__2->loot_functions[8]), 5, 17);
     create_set_count(&(loot_pool__2->loot_functions[9]), 1, 1);
-    LootPool* loot_pool__3 = &(context.loot_pools[3]);
-    LootPool* loot_pool__4 = &(context.loot_pools[4]);
 }
 
 LootTableContext* init_bastion_other_1_21_1() {

--- a/loot/loot_tables/chests/bastion_other_1_21_9.c
+++ b/loot/loot_tables/chests/bastion_other_1_21_9.c
@@ -172,8 +172,6 @@ static void create_loot_functions() {
     create_set_count(&(loot_pool__2->loot_functions[7]), 4, 6);
     create_set_count(&(loot_pool__2->loot_functions[8]), 5, 17);
     create_set_count(&(loot_pool__2->loot_functions[9]), 1, 1);
-    LootPool* loot_pool__3 = &(context.loot_pools[3]);
-    LootPool* loot_pool__4 = &(context.loot_pools[4]);
 }
 
 LootTableContext* init_bastion_other_1_21_9() {

--- a/loot/loot_tables/chests/buried_treasure_1_13.c
+++ b/loot/loot_tables/chests/buried_treasure_1_13.c
@@ -128,7 +128,6 @@ static LootTableContext context = {
 };
 
 static void create_loot_functions() {
-    LootPool* loot_pool__0 = &(context.loot_pools[0]);
     LootPool* loot_pool__1 = &(context.loot_pools[1]);
     create_set_count(&(loot_pool__1->loot_functions[0]), 1, 4);
     create_set_count(&(loot_pool__1->loot_functions[1]), 1, 4);
@@ -137,7 +136,6 @@ static void create_loot_functions() {
     create_set_count(&(loot_pool__2->loot_functions[0]), 4, 8);
     create_set_count(&(loot_pool__2->loot_functions[1]), 1, 2);
     create_set_count(&(loot_pool__2->loot_functions[2]), 1, 5);
-    LootPool* loot_pool__3 = &(context.loot_pools[3]);
     LootPool* loot_pool__4 = &(context.loot_pools[4]);
     create_set_count(&(loot_pool__4->loot_functions[0]), 2, 4);
     create_set_count(&(loot_pool__4->loot_functions[1]), 2, 4);

--- a/loot/loot_tables/chests/buried_treasure_1_18.c
+++ b/loot/loot_tables/chests/buried_treasure_1_18.c
@@ -148,7 +148,6 @@ static LootTableContext context = {
 };
 
 static void create_loot_functions() {
-    LootPool* loot_pool__0 = &(context.loot_pools[0]);
     LootPool* loot_pool__1 = &(context.loot_pools[1]);
     create_set_count(&(loot_pool__1->loot_functions[0]), 1, 4);
     create_set_count(&(loot_pool__1->loot_functions[1]), 1, 4);
@@ -157,7 +156,6 @@ static void create_loot_functions() {
     create_set_count(&(loot_pool__2->loot_functions[0]), 4, 8);
     create_set_count(&(loot_pool__2->loot_functions[1]), 1, 2);
     create_set_count(&(loot_pool__2->loot_functions[2]), 1, 5);
-    LootPool* loot_pool__3 = &(context.loot_pools[3]);
     LootPool* loot_pool__4 = &(context.loot_pools[4]);
     create_set_count(&(loot_pool__4->loot_functions[0]), 2, 4);
     create_set_count(&(loot_pool__4->loot_functions[1]), 2, 4);

--- a/loot/loot_tables/chests/buried_treasure_1_21_11.c
+++ b/loot/loot_tables/chests/buried_treasure_1_21_11.c
@@ -168,7 +168,6 @@ static LootTableContext context = {
 };
 
 static void create_loot_functions() {
-    LootPool* loot_pool__0 = &(context.loot_pools[0]);
     LootPool* loot_pool__1 = &(context.loot_pools[1]);
     create_set_count(&(loot_pool__1->loot_functions[0]), 1, 4);
     create_set_count(&(loot_pool__1->loot_functions[1]), 1, 4);
@@ -177,7 +176,6 @@ static void create_loot_functions() {
     create_set_count(&(loot_pool__2->loot_functions[0]), 4, 8);
     create_set_count(&(loot_pool__2->loot_functions[1]), 1, 2);
     create_set_count(&(loot_pool__2->loot_functions[2]), 1, 5);
-    LootPool* loot_pool__3 = &(context.loot_pools[3]);
     LootPool* loot_pool__4 = &(context.loot_pools[4]);
     create_set_count(&(loot_pool__4->loot_functions[0]), 2, 4);
     create_set_count(&(loot_pool__4->loot_functions[1]), 2, 4);

--- a/loot/loot_tables/chests/end_city_treasure_1_20.c
+++ b/loot/loot_tables/chests/end_city_treasure_1_20.c
@@ -88,7 +88,6 @@ static void create_loot_functions() {
     create_enchant_with_levels(&(loot_pool__0->loot_functions[16]), MC_1_20, "minecraft:iron_helmet", get_item_type("minecraft:iron_helmet"), 20, 39, 1);
     create_enchant_with_levels(&(loot_pool__0->loot_functions[17]), MC_1_20, "minecraft:iron_pickaxe", get_item_type("minecraft:iron_pickaxe"), 20, 39, 1);
     create_enchant_with_levels(&(loot_pool__0->loot_functions[18]), MC_1_20, "minecraft:iron_shovel", get_item_type("minecraft:iron_shovel"), 20, 39, 1);
-    LootPool* loot_pool__1 = &(context.loot_pools[1]);
 }
 
 LootTableContext* init_end_city_treasure_1_20() {

--- a/loot/loot_tables/chests/end_city_treasure_1_21_11.c
+++ b/loot/loot_tables/chests/end_city_treasure_1_21_11.c
@@ -89,7 +89,6 @@ static void create_loot_functions() {
     create_enchant_with_levels_tag(&(loot_pool__0->loot_functions[17]), MC_1_21_11, "minecraft:iron_helmet", get_item_type("minecraft:iron_helmet"), 20, 39, "#minecraft:on_random_loot", 1);
     create_enchant_with_levels_tag(&(loot_pool__0->loot_functions[18]), MC_1_21_11, "minecraft:iron_pickaxe", get_item_type("minecraft:iron_pickaxe"), 20, 39, "#minecraft:on_random_loot", 1);
     create_enchant_with_levels_tag(&(loot_pool__0->loot_functions[19]), MC_1_21_11, "minecraft:iron_shovel", get_item_type("minecraft:iron_shovel"), 20, 39, "#minecraft:on_random_loot", 1);
-    LootPool* loot_pool__1 = &(context.loot_pools[1]);
 }
 
 LootTableContext* init_end_city_treasure_1_21_11() {

--- a/loot/loot_tables/chests/end_city_treasure_1_21_9.c
+++ b/loot/loot_tables/chests/end_city_treasure_1_21_9.c
@@ -88,7 +88,6 @@ static void create_loot_functions() {
     create_enchant_with_levels_tag(&(loot_pool__0->loot_functions[16]), MC_1_21_9, "minecraft:iron_helmet", get_item_type("minecraft:iron_helmet"), 20, 39, "#minecraft:on_random_loot", 1);
     create_enchant_with_levels_tag(&(loot_pool__0->loot_functions[17]), MC_1_21_9, "minecraft:iron_pickaxe", get_item_type("minecraft:iron_pickaxe"), 20, 39, "#minecraft:on_random_loot", 1);
     create_enchant_with_levels_tag(&(loot_pool__0->loot_functions[18]), MC_1_21_9, "minecraft:iron_shovel", get_item_type("minecraft:iron_shovel"), 20, 39, "#minecraft:on_random_loot", 1);
-    LootPool* loot_pool__1 = &(context.loot_pools[1]);
 }
 
 LootTableContext* init_end_city_treasure_1_21_9() {

--- a/loot/loot_tables/chests/igloo_chest_1_13.c
+++ b/loot/loot_tables/chests/igloo_chest_1_13.c
@@ -73,7 +73,6 @@ static void create_loot_functions() {
     create_set_count(&(loot_pool__0->loot_functions[1]), 1, 4);
     create_set_count(&(loot_pool__0->loot_functions[2]), 1, 3);
     create_set_count(&(loot_pool__0->loot_functions[3]), 2, 3);
-    LootPool* loot_pool__1 = &(context.loot_pools[1]);
 }
 
 LootTableContext* init_igloo_chest_1_13() {

--- a/loot/loot_tables/chests/nether_bridge_1_20.c
+++ b/loot/loot_tables/chests/nether_bridge_1_20.c
@@ -74,7 +74,6 @@ static void create_loot_functions() {
     create_set_count(&(loot_pool__0->loot_functions[2]), 1, 3);
     create_set_count(&(loot_pool__0->loot_functions[3]), 3, 7);
     create_set_count(&(loot_pool__0->loot_functions[4]), 2, 4);
-    LootPool* loot_pool__1 = &(context.loot_pools[1]);
 }
 
 LootTableContext* init_nether_bridge_1_20() {

--- a/loot/loot_tables/chests/nether_bridge_1_21_9.c
+++ b/loot/loot_tables/chests/nether_bridge_1_21_9.c
@@ -74,7 +74,6 @@ static void create_loot_functions() {
     create_set_count(&(loot_pool__0->loot_functions[2]), 1, 3);
     create_set_count(&(loot_pool__0->loot_functions[3]), 3, 7);
     create_set_count(&(loot_pool__0->loot_functions[4]), 2, 4);
-    LootPool* loot_pool__1 = &(context.loot_pools[1]);
 }
 
 LootTableContext* init_nether_bridge_1_21_9() {

--- a/loot/loot_tables/chests/pillager_outpost_1_14.c
+++ b/loot/loot_tables/chests/pillager_outpost_1_14.c
@@ -108,7 +108,6 @@ static LootTableContext context = {
 };
 
 static void create_loot_functions() {
-    LootPool* loot_pool__0 = &(context.loot_pools[0]);
     LootPool* loot_pool__1 = &(context.loot_pools[1]);
     create_set_count(&(loot_pool__1->loot_functions[0]), 3, 5);
     create_set_count(&(loot_pool__1->loot_functions[1]), 2, 5);

--- a/loot/loot_tables/chests/pillager_outpost_1_19_2.c
+++ b/loot/loot_tables/chests/pillager_outpost_1_19_2.c
@@ -128,7 +128,6 @@ static LootTableContext context = {
 };
 
 static void create_loot_functions() {
-    LootPool* loot_pool__0 = &(context.loot_pools[0]);
     LootPool* loot_pool__1 = &(context.loot_pools[1]);
     create_set_count(&(loot_pool__1->loot_functions[0]), 3, 5);
     create_set_count(&(loot_pool__1->loot_functions[1]), 2, 5);

--- a/loot/loot_tables/chests/pillager_outpost_1_20.c
+++ b/loot/loot_tables/chests/pillager_outpost_1_20.c
@@ -148,7 +148,6 @@ static LootTableContext context = {
 };
 
 static void create_loot_functions() {
-    LootPool* loot_pool__0 = &(context.loot_pools[0]);
     LootPool* loot_pool__1 = &(context.loot_pools[1]);
     create_set_count(&(loot_pool__1->loot_functions[0]), 3, 5);
     create_set_count(&(loot_pool__1->loot_functions[1]), 2, 5);

--- a/loot/loot_tables/chests/pillager_outpost_1_21_11.c
+++ b/loot/loot_tables/chests/pillager_outpost_1_21_11.c
@@ -148,7 +148,6 @@ static LootTableContext context = {
 };
 
 static void create_loot_functions() {
-    LootPool* loot_pool__0 = &(context.loot_pools[0]);
     LootPool* loot_pool__1 = &(context.loot_pools[1]);
     create_set_count(&(loot_pool__1->loot_functions[0]), 3, 5);
     create_set_count(&(loot_pool__1->loot_functions[1]), 2, 5);

--- a/loot/loot_tables/chests/stronghold_corridor_1_20.c
+++ b/loot/loot_tables/chests/stronghold_corridor_1_20.c
@@ -76,7 +76,6 @@ static void create_loot_functions() {
     create_set_count(&(loot_pool__0->loot_functions[4]), 1, 3);
     create_set_count(&(loot_pool__0->loot_functions[5]), 1, 3);
     create_enchant_with_levels(&(loot_pool__0->loot_functions[6]), MC_1_20, "minecraft:book", get_item_type("minecraft:book"), 30, 30, 1);
-    LootPool* loot_pool__1 = &(context.loot_pools[1]);
 }
 
 LootTableContext* init_stronghold_corridor_1_20() {

--- a/loot/loot_tables/chests/stronghold_corridor_1_21_6.c
+++ b/loot/loot_tables/chests/stronghold_corridor_1_21_6.c
@@ -77,7 +77,6 @@ static void create_loot_functions() {
     create_set_count(&(loot_pool__0->loot_functions[5]), 1, 3);
     create_set_count(&(loot_pool__0->loot_functions[6]), 1, 5);
     create_enchant_with_levels_tag(&(loot_pool__0->loot_functions[7]), MC_1_21_6, "minecraft:book", get_item_type("minecraft:book"), 30, 30, "#minecraft:on_random_loot", 1);
-    LootPool* loot_pool__1 = &(context.loot_pools[1]);
 }
 
 LootTableContext* init_stronghold_corridor_1_21_6() {

--- a/loot/loot_tables/chests/stronghold_corridor_1_21_9.c
+++ b/loot/loot_tables/chests/stronghold_corridor_1_21_9.c
@@ -77,7 +77,6 @@ static void create_loot_functions() {
     create_set_count(&(loot_pool__0->loot_functions[5]), 1, 3);
     create_set_count(&(loot_pool__0->loot_functions[6]), 1, 5);
     create_enchant_with_levels_tag(&(loot_pool__0->loot_functions[7]), MC_1_21_9, "minecraft:book", get_item_type("minecraft:book"), 30, 30, "#minecraft:on_random_loot", 1);
-    LootPool* loot_pool__1 = &(context.loot_pools[1]);
 }
 
 LootTableContext* init_stronghold_corridor_1_21_9() {

--- a/loot/loot_tables/chests/stronghold_library_1_20.c
+++ b/loot/loot_tables/chests/stronghold_library_1_20.c
@@ -72,7 +72,6 @@ static void create_loot_functions() {
     create_set_count(&(loot_pool__0->loot_functions[0]), 1, 3);
     create_set_count(&(loot_pool__0->loot_functions[1]), 2, 7);
     create_enchant_with_levels(&(loot_pool__0->loot_functions[2]), MC_1_20, "minecraft:book", get_item_type("minecraft:book"), 30, 30, 1);
-    LootPool* loot_pool__1 = &(context.loot_pools[1]);
 }
 
 LootTableContext* init_stronghold_library_1_20() {

--- a/loot/loot_tables/chests/trial_chambers/reward_1_21_1.c
+++ b/loot/loot_tables/chests/trial_chambers/reward_1_21_1.c
@@ -93,8 +93,6 @@ static LootTableContext context = {
 };
 
 static void create_loot_functions() {
-    LootPool* loot_pool__0 = &(context.loot_pools[0]);
-    LootPool* loot_pool__1 = &(context.loot_pools[1]);
     LootPool* loot_pool__2 = &(context.loot_pools[2]);
     create_random_chance(&(loot_pool__2->conditions[0]), 0.25f);
 }

--- a/loot/loot_tables/chests/trial_chambers/reward_ominous_1_21_1.c
+++ b/loot/loot_tables/chests/trial_chambers/reward_ominous_1_21_1.c
@@ -93,8 +93,6 @@ static LootTableContext context = {
 };
 
 static void create_loot_functions() {
-    LootPool* loot_pool__0 = &(context.loot_pools[0]);
-    LootPool* loot_pool__1 = &(context.loot_pools[1]);
     LootPool* loot_pool__2 = &(context.loot_pools[2]);
     create_random_chance(&(loot_pool__2->conditions[0]), 0.75f);
 }

--- a/loot/loot_tables/chests/trial_chambers/reward_ominous_unique_1_21_1.c
+++ b/loot/loot_tables/chests/trial_chambers/reward_ominous_unique_1_21_1.c
@@ -47,7 +47,8 @@ static LootTableContext context = {
     .loot_pools = loot_pools,
 };
 
-static void create_loot_functions() {}
+static void create_loot_functions() {
+}
 
 LootTableContext* init_reward_ominous_unique_1_21_1() {
     if (!initialised) {

--- a/loot/loot_tables/chests/trial_chambers/reward_ominous_unique_1_21_1.c
+++ b/loot/loot_tables/chests/trial_chambers/reward_ominous_unique_1_21_1.c
@@ -47,9 +47,7 @@ static LootTableContext context = {
     .loot_pools = loot_pools,
 };
 
-static void create_loot_functions() {
-    LootPool* loot_pool__0 = &(context.loot_pools[0]);
-}
+static void create_loot_functions() {}
 
 LootTableContext* init_reward_ominous_unique_1_21_1() {
     if (!initialised) {

--- a/loot/loot_tables/chests/trial_chambers/reward_unique_1_21_1.c
+++ b/loot/loot_tables/chests/trial_chambers/reward_unique_1_21_1.c
@@ -47,7 +47,8 @@ static LootTableContext context = {
     .loot_pools = loot_pools,
 };
 
-static void create_loot_functions() {}
+static void create_loot_functions() {
+}
 
 LootTableContext* init_reward_unique_1_21_1() {
     if (!initialised) {

--- a/loot/loot_tables/chests/trial_chambers/reward_unique_1_21_1.c
+++ b/loot/loot_tables/chests/trial_chambers/reward_unique_1_21_1.c
@@ -47,9 +47,7 @@ static LootTableContext context = {
     .loot_pools = loot_pools,
 };
 
-static void create_loot_functions() {
-    LootPool* loot_pool__0 = &(context.loot_pools[0]);
-}
+static void create_loot_functions() {}
 
 LootTableContext* init_reward_unique_1_21_1() {
     if (!initialised) {

--- a/noise.c
+++ b/noise.c
@@ -46,7 +46,7 @@ static inline double indexedLerp(uint8_t idx, double a, double b, double c)
 }
 #endif
 
-void perlinInit(PerlinNoise *restrict noise, uint64_t *restrict seed)
+void perlinInit(PerlinNoise *__restrict noise, uint64_t *__restrict seed)
 {
     int i = 0;
     //memset(noise, 0, sizeof(*noise));
@@ -76,7 +76,7 @@ void perlinInit(PerlinNoise *restrict noise, uint64_t *restrict seed)
     noise->t2 = d2*d2*d2 * (d2 * (d2*6.0-15.0) + 10.0);
 }
 
-void xPerlinInit(PerlinNoise *restrict noise, Xoroshiro *restrict xr)
+void xPerlinInit(PerlinNoise *__restrict noise, Xoroshiro *__restrict xr)
 {
     int i = 0;
     //memset(noise, 0, sizeof(*noise));

--- a/noise.h
+++ b/noise.h
@@ -45,8 +45,8 @@ double maintainPrecision(double x)
 }
 
 /// Perlin noise
-void perlinInit(PerlinNoise *restrict noise, uint64_t *restrict seed);
-void xPerlinInit(PerlinNoise *restrict noise, Xoroshiro *restrict xr);
+void perlinInit(PerlinNoise *__restrict noise, uint64_t *__restrict seed);
+void xPerlinInit(PerlinNoise *__restrict noise, Xoroshiro *__restrict xr);
 
 double samplePerlin(const PerlinNoise *noise, double x, double y, double z,
         double yamp, double ymax);

--- a/quadbase.c
+++ b/quadbase.c
@@ -8,14 +8,26 @@
 #include <sys/stat.h>
 
 
+#ifdef IS_DIR_SEP
+    #undef IS_DIR_SEP
+#endif
 #if defined(_WIN32)
 
 #include <windows.h>
 typedef HANDLE thread_id_t;
 #include <direct.h>
 #define IS_DIR_SEP(C)   ((C) == '/' || (C) == '\\')
+#ifdef stat
+    #undef stat
+#endif
 #define stat            _stat
+#ifdef mkdir
+    #undef mkdir
+#endif
 #define mkdir(P,X)      _mkdir(P)
+#ifdef S_IFDIR
+    #undef S_IFDIR
+#endif
 #define S_IFDIR         _S_IFDIR
 
 #ifndef _S_ISTYPE
@@ -28,6 +40,9 @@ typedef HANDLE thread_id_t;
 
 #else
 
+#ifdef USE_PTHREAD
+    #undef USE_PTHREAD
+#endif
 #define USE_PTHREAD
 #include <pthread.h>
 typedef pthread_t       thread_id_t;
@@ -223,6 +238,9 @@ Pos getOptimalAfk(Pos p[4], int ax, int ay, int az, int *spcnt)
 }
 
 
+#ifdef MAX_PATHLEN
+    #undef MAX_PATHLEN
+#endif
 #define MAX_PATHLEN 4096
 
 STRUCT(linked_seeds_t)

--- a/quadbase.c
+++ b/quadbase.c
@@ -8,26 +8,14 @@
 #include <sys/stat.h>
 
 
-#ifdef IS_DIR_SEP
-    #undef IS_DIR_SEP
-#endif
 #if defined(_WIN32)
 
 #include <windows.h>
 typedef HANDLE thread_id_t;
 #include <direct.h>
 #define IS_DIR_SEP(C)   ((C) == '/' || (C) == '\\')
-#ifdef stat
-    #undef stat
-#endif
 #define stat            _stat
-#ifdef mkdir
-    #undef mkdir
-#endif
 #define mkdir(P,X)      _mkdir(P)
-#ifdef S_IFDIR
-    #undef S_IFDIR
-#endif
 #define S_IFDIR         _S_IFDIR
 
 #ifndef _S_ISTYPE
@@ -40,9 +28,6 @@ typedef HANDLE thread_id_t;
 
 #else
 
-#ifdef USE_PTHREAD
-    #undef USE_PTHREAD
-#endif
 #define USE_PTHREAD
 #include <pthread.h>
 typedef pthread_t       thread_id_t;
@@ -238,9 +223,6 @@ Pos getOptimalAfk(Pos p[4], int ax, int ay, int az, int *spcnt)
 }
 
 
-#ifdef MAX_PATHLEN
-    #undef MAX_PATHLEN
-#endif
 #define MAX_PATHLEN 4096
 
 STRUCT(linked_seeds_t)

--- a/rng.h
+++ b/rng.h
@@ -89,10 +89,9 @@ static inline uint32_t BSWAP32(uint32_t x) {
 
 #endif
 
-#ifdef restrict
-#undef restrict
+#ifndef __restrict
+#define __restrict
 #endif
-#define restrict __restrict
 
 /// imitate amd64/x64 rotate instructions
 
@@ -384,7 +383,8 @@ static inline int xNextIntJBetween(Xoroshiro *xr, const int min, const int max)
 static inline Xoroshiro xAtPos(Xoroshiro xr, int x, int y, int z)
 {
     uint64_t l = getSeedAt(x, y, z);
-    return (Xoroshiro) {l ^ xr.lo, xr.hi};
+    Xoroshiro xr2 = {l ^ xr.lo, xr.hi};
+    return xr2;
 }
 
 enum {

--- a/rng.h
+++ b/rng.h
@@ -1,6 +1,9 @@
 #ifndef RNG_H_
 #define RNG_H_
 
+#ifdef __STDC_FORMAT_MACROS
+    #undef __STDC_FORMAT_MACROS
+#endif
 #define __STDC_FORMAT_MACROS 1
 
 #include <stdlib.h>
@@ -26,9 +29,33 @@ typedef float       f32;
 typedef double      f64;
 
 
+#ifdef STRUCT
+    #undef STRUCT
+#endif
 #define STRUCT(S) typedef struct S S; struct S
 #define UNION(S) typedef union S S; union S
 
+#ifdef IABS
+    #undef IABS
+#endif
+#ifdef PREFETCH
+    #undef PREFETCH
+#endif
+#ifdef likely
+    #undef likely
+#endif
+#ifdef unlikely
+    #undef unlikely
+#endif
+#ifdef ATTR
+    #undef ATTR
+#endif
+#ifdef BSWAP32
+    #undef BSWAP32
+#endif
+#ifdef UNREACHABLE
+    #undef UNREACHABLE
+#endif
 #ifdef __GNUC__
 
 #define IABS(X)                 __builtin_abs(X)
@@ -57,6 +84,10 @@ static inline uint32_t BSWAP32(uint32_t x) {
 #define UNREACHABLE()           exit(1) // [[noreturn]]
 #endif
 
+#endif
+
+#if defined(__cplusplus) && !defined(restrict)
+    #define restrict
 #endif
 
 /// imitate amd64/x64 rotate instructions
@@ -150,6 +181,9 @@ static inline double nextDouble(uint64_t *seed)
  * This is a macro and not an inline function, as many compilers can make use
  * of the additional optimisation passes for the surrounding code.
  */
+#ifdef JAVA_NEXT_INT24
+    #undef JAVA_NEXT_INT24
+#endif
 #define JAVA_NEXT_INT24(S,X)                \
     do {                                    \
         uint64_t a = (1ULL << 48) - 1;      \
@@ -346,8 +380,8 @@ static inline int xNextIntJBetween(Xoroshiro *xr, const int min, const int max)
 static inline Xoroshiro xAtPos(Xoroshiro xr, int x, int y, int z)
 {
     uint64_t l = getSeedAt(x, y, z);
-
-    return (Xoroshiro) {l ^ xr.lo, xr.hi};
+    Xoroshiro xr2 = {l ^ xr.lo, xr.hi};
+    return xr2;
 }
 
 enum {

--- a/rng.h
+++ b/rng.h
@@ -2,7 +2,7 @@
 #define RNG_H_
 
 #ifdef __STDC_FORMAT_MACROS
-    #undef __STDC_FORMAT_MACROS
+#undef __STDC_FORMAT_MACROS
 #endif
 #define __STDC_FORMAT_MACROS 1
 
@@ -30,31 +30,34 @@ typedef double      f64;
 
 
 #ifdef STRUCT
-    #undef STRUCT
+#undef STRUCT
 #endif
 #define STRUCT(S) typedef struct S S; struct S
+#ifdef UNION
+#undef UNION
+#endif
 #define UNION(S) typedef union S S; union S
 
 #ifdef IABS
-    #undef IABS
+#undef IABS
 #endif
 #ifdef PREFETCH
-    #undef PREFETCH
+#undef PREFETCH
 #endif
 #ifdef likely
-    #undef likely
+#undef likely
 #endif
 #ifdef unlikely
-    #undef unlikely
+#undef unlikely
 #endif
 #ifdef ATTR
-    #undef ATTR
+#undef ATTR
 #endif
 #ifdef BSWAP32
-    #undef BSWAP32
+#undef BSWAP32
 #endif
 #ifdef UNREACHABLE
-    #undef UNREACHABLE
+#undef UNREACHABLE
 #endif
 #ifdef __GNUC__
 
@@ -86,9 +89,10 @@ static inline uint32_t BSWAP32(uint32_t x) {
 
 #endif
 
-#if defined(__cplusplus) && !defined(restrict)
-    #define restrict
+#ifdef restrict
+#undef restrict
 #endif
+#define restrict __restrict
 
 /// imitate amd64/x64 rotate instructions
 
@@ -177,13 +181,13 @@ static inline double nextDouble(uint64_t *seed)
     return (int64_t) x / (double) (1ULL << 53);
 }
 
+#ifdef JAVA_NEXT_INT24
+#undef JAVA_NEXT_INT24
+#endif
 /* A macro to generate the ideal assembly for X = nextInt(*S, 24)
  * This is a macro and not an inline function, as many compilers can make use
  * of the additional optimisation passes for the surrounding code.
  */
-#ifdef JAVA_NEXT_INT24
-    #undef JAVA_NEXT_INT24
-#endif
 #define JAVA_NEXT_INT24(S,X)                \
     do {                                    \
         uint64_t a = (1ULL << 48) - 1;      \
@@ -380,8 +384,7 @@ static inline int xNextIntJBetween(Xoroshiro *xr, const int min, const int max)
 static inline Xoroshiro xAtPos(Xoroshiro xr, int x, int y, int z)
 {
     uint64_t l = getSeedAt(x, y, z);
-    Xoroshiro xr2 = {l ^ xr.lo, xr.hi};
-    return xr2;
+    return (Xoroshiro) {l ^ xr.lo, xr.hi};
 }
 
 enum {

--- a/xradv.c
+++ b/xradv.c
@@ -5,6 +5,9 @@
 #include "rng.h"
 #include "xrms.h"
 
+#ifdef MAT_SIZE
+    #undef MAT_SIZE
+#endif
 #define MAT_SIZE sizeof(uint64_t) * 128 * 2
 
 static void calcMatPows(uint64_t m[128][2]);

--- a/xradv.c
+++ b/xradv.c
@@ -5,9 +5,6 @@
 #include "rng.h"
 #include "xrms.h"
 
-#ifdef MAT_SIZE
-    #undef MAT_SIZE
-#endif
 #define MAT_SIZE sizeof(uint64_t) * 128 * 2
 
 static void calcMatPows(uint64_t m[128][2]);

--- a/xrms.h
+++ b/xrms.h
@@ -3,6 +3,9 @@
 
 #include <stdint.h>
 
+#ifdef POWS_OF_2
+    #undef POWS_OF_2
+#endif
 #define POWS_OF_2 64
 
 static const uint64_t xrms[POWS_OF_2][128][2] = {

--- a/xrms.h
+++ b/xrms.h
@@ -4,7 +4,7 @@
 #include <stdint.h>
 
 #ifdef POWS_OF_2
-    #undef POWS_OF_2
+#undef POWS_OF_2
 #endif
 #define POWS_OF_2 64
 


### PR DESCRIPTION
The most recent commit "[a]dd[ed] restrict to fix LTO regression". Unfortunately, `restrict` is a C-only keyword (not C++), and therefore breaks the repository when attempting to link it with C++ code in clang.
In addition, this implements all of the changes in https://github.com/Cubitect/cubiomes/pull/133, alongside some others. The exact changelist is:
- BREAKING CHANGE: Move stronghold and approximate spawn coordinates to corners of their chunks instead of having (4, 4)/(8, 8) offsets. (With this, strongholds' coordinates match their in-game /locate coordinates. Also, the first coordinate checked for 1.18+ spawn algorithms is the Northwest corner, so this is a better estimate for spawnpoints on average.)
- Feature: Clearer compilation commands + more accurate spawn algorithm description in Readme
- Patch: Fix restrict not being a C++ keyword, preventing clang++ compilation
- Patch: Expand .gitignore to hide Cmake-generated files
- Patch: Add #undef safeguards for all #define keywords
- Patch: Add warning about MAX/MIN macros
- Patch: Fix incorrect 1.8- fallback first-stage spawn coordinate
- Patch: Silence compiler warnings about unused variables
- Patch: Fix inaccurate Readme description of Cubiomes Viewer
- Patch: Rewrite non-portable compound literal